### PR TITLE
Change URL to download boost from old version to new one.

### DIFF
--- a/docker/ubuntu/base/Dockerfile
+++ b/docker/ubuntu/base/Dockerfile
@@ -22,7 +22,7 @@ RUN mkdir -p $DOCKER_BUILD_DIR
 # Boost
 RUN cd ${DOCKER_BUILD_DIR} \
     && export BOOST_VERSION_FILE=${BOOST_VERSION//./_} \
-    && wget --quiet https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_FILE}.tar.gz \
+    && wget --quiet https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_FILE}.tar.gz \
     && tar -xzf boost_${BOOST_VERSION_FILE}.tar.gz \
     && cd boost_${BOOST_VERSION_FILE} \
     && /bin/bash ./bootstrap.sh \


### PR DESCRIPTION
This PR is a quick fix for deprecated URL used to download boost source code.

When I tried to build a docker container image by the commands below, I encountered build error.

```
git clone https://github.com/nict-wisdom/rannc.git
cd rannc/docker/ubuntu
sudo make CUDA_VERSION=11.1.1 PYTHON_VERSION=3.8 OS_VERSION=20.04
```

As far as I investigated it, it looks like 403 forbidden error happened when downloading boost's source code.

In the current Dockerfile, the hostname in the target URL is `dl.bintray.com`, however, actual hostname of the URL that we can see in the official boost website is `boostorg.jfrog.io`.

According to the following article, Bintray is shutting down so this Dockerfile should be access to newer URL.

- EN: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/
- JA: https://jfrog.com/ja/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/