### PR TITLE
Fixed memory leak and did some refactoring

### DIFF
--- a/src/comp/GraphProfiler.cpp
+++ b/src/comp/GraphProfiler.cpp
@@ -237,8 +237,6 @@ std::pair<IValueMap, GraphProfile> GraphProfiler::computeGraph(
     const DriverExecConf& conf) {
   emptyCache();
 
-  ProfilingResult ret_profiles;
-
   const std::string& id = subgraph->getName();
   std::string fwd_time_key = getFwdTimeKey(id);
   std::string bwd_time_key = getBwdTimeKey(id);
@@ -356,13 +354,14 @@ std::pair<IValueMap, GraphProfile> GraphProfiler::computeGraph(
       work_mem, // gradients
       conf.checkpointing};
 
+  logger->trace("{}", toString(prof));
+
   return {driver_out, prof};
 }
 
 ProfilingResult GraphProfiler::compute(
     const ProfilingInput& input, IValueMap& values, int split_index,
     bool trace_dim_names) {
-  TimeCounter time_counter(true);
   ProfilingResult ret_profiles;
   std::unordered_set<std::string> graphs_done;
 
@@ -744,9 +743,9 @@ ProfilingResult GraphProfiler::init(bool trace_dim_names) {
     }
   }
 
-  const auto graph_params =
-      getGraphParams(base_graph_, TensorPartitioningGraphInfo{});
   if (trace_dim_names) {
+    const auto graph_params =
+        getGraphParams(base_graph_, TensorPartitioningGraphInfo{});
     for (const auto& p_it : graph_params) {
       const auto dim_names = createDimnames(p_it.first, p_it.second, false);
       dim_names_[p_it.first] = dim_names;

--- a/src/comp/GraphProfiler.h
+++ b/src/comp/GraphProfiler.h
@@ -31,9 +31,15 @@ struct GraphProfile {
 
   friend std::ostream& operator<<(
       std::ostream& os, const GraphProfile& profile) {
-    os << "name: " << profile.name << " fwd_time: " << profile.fwd_time
+    os << "name: " << profile.name
+       << " fwd_time: " << profile.fwd_time
        << " bwd_time: " << profile.bwd_time
        << " max_allocated_mem: " << profile.max_allocated_mem
+       << " param_size: " << profile.param_size
+       << " input_size: " << profile.input_size
+       << " output_size: " << profile.output_size
+       << " activation_size: " << profile.activation_size
+       << " working_mem: " << profile.working_mem
        << " checkpointing: " << profile.checkpointing;
     return os;
   }

--- a/src/torch/TorchDriver.cpp
+++ b/src/torch/TorchDriver.cpp
@@ -849,6 +849,7 @@ void TorchDriver::destroyModule(const std::string& id) {
   last_inputs_.erase(id);
   last_outputs_.erase(id);
   ir_graphs_.erase(id);
+  clone_input_ir_graphs_.erase(id);
   subgraph_ids_.erase(id);
 
   param_tensors_.erase(id);
@@ -859,6 +860,8 @@ void TorchDriver::destroyModule(const std::string& id) {
   functions_.erase(id);
 
   buffer_cache_.erase(id);
+  constants_.erase(id);
+  func_storages_.erase(id);
 }
 
 void TorchDriver::destroy() {

--- a/src/torch/TorchDriver.h
+++ b/src/torch/TorchDriver.h
@@ -162,7 +162,6 @@ class TorchDriver {
   std::unordered_map<std::string, IValueMap> constants_;
   std::unordered_map<std::string, std::shared_ptr<FunctionStorage>>
       func_storages_;
-  std::unordered_map<std::string, DriverExecConf> exec_conf_;
 
   int last_split_idx_ = INT32_MAX;
 


### PR DESCRIPTION
I fixed a memory leak issue that became problematic in my CPU-only environment.

Summarizing the issues,
- The lifetime of `graph_params` was too long
- Some cleanups for newly introduced members were missing in the `destroy` method of `TorchDriver`.

Additionally, I would like to share some small cleanup and logging code which might help you.