### PR TITLE
Assign batch sizes to IR graphs and values to fix inconsistency of the first dim size

### DIFF
--- a/src/comm/SComm.cpp
+++ b/src/comm/SComm.cpp
@@ -449,9 +449,9 @@ torch::jit::IValue SComm::doDistribute(
 torch::jit::IValue SComm::distribute(
     const torch::jit::IValue& val, const RouteDP& route, bool is_bwd,
     int split_delay) {
-  auto ir_type = route.ir_value.getType();
-  ir_type.setBatchSize(getCurrentSplitBatchSize(split_delay));
-  return distribute(val, route, is_bwd, ir_type, split_delay);
+  auto ir_value = route.ir_value;
+  ir_value.setBatchSize(getCurrentSplitBatchSize(split_delay));
+  return distribute(val, route, is_bwd, ir_value.getType(), split_delay);
 }
 
 torch::jit::IValue SComm::distribute(

--- a/src/comp/BatchSizeCalculator.cpp
+++ b/src/comp/BatchSizeCalculator.cpp
@@ -153,9 +153,6 @@ std::unordered_map<int, std::vector<int64_t>> BatchSizeCalculator::
     calcDistBatchDims(
         const std::vector<int64_t>& global_dim,
         const std::unordered_set<int>& ranks, int split_index) const {
-  std::vector<int> vec_ranks = rannc::setToVector(ranks);
-  std::sort(vec_ranks.begin(), vec_ranks.end());
-
   assert(!global_dim.empty());
 
   int64_t split_bs = getGlobalSplitBatchSize(split_index);

--- a/src/comp/GraphProfiler.cpp
+++ b/src/comp/GraphProfiler.cpp
@@ -92,7 +92,7 @@ std::shared_ptr<IRGraph> setInputTypes(
 
   return std::make_shared<IRGraph>(
       g->getName(), g->getNodes(), values, g->getInputNames(),
-      g->getOutputNames());
+      g->getOutputNames(), g->getBatchSize());
 }
 
 std::unordered_map<std::string, at::Tensor> paramsToCuda(
@@ -783,7 +783,7 @@ ProfilingResult GraphProfiler::init(bool trace_dim_names) {
 
     const auto& id = n.getId();
     graphs[id] = std::make_shared<IRGraph>(
-        id, pf_nodes, pf_values, input_names, n.getOutputNames());
+        id, pf_nodes, pf_values, input_names, n.getOutputNames(), 0);
     node_map[id] = n;
 
     repl_nums[id] = dev_num_;

--- a/src/comp/RaNNCModule.cpp
+++ b/src/comp/RaNNCModule.cpp
@@ -207,7 +207,7 @@ std::vector<long> RaNNCModule::init(
     logger->debug("Traced graph: {}", graph->toString());
     logger->info("Converting torch model to IR ...");
   }
-  ir_graph_ = fromTorch(id_, graph, args.size());
+  ir_graph_ = fromTorch(id_, graph, args.size(), local_batch_size);
 
   if (ir_graph_->getNodes().empty()) {
     std::stringstream ss;

--- a/src/distop/PartitionTensor.cpp
+++ b/src/distop/PartitionTensor.cpp
@@ -222,7 +222,7 @@ TensorPartitioningGraphInfo insertGather(
 
   part_info.graph = std::make_shared<IRGraph>(
       g->getName(), new_nodes, new_values, g->getInputNames(),
-      g->getOutputNames());
+      g->getOutputNames(), g->getBatchSize());
 
   return part_info;
 }
@@ -290,7 +290,7 @@ TensorPartitioningGraphInfo replaceWithDistOp(
 
   std::shared_ptr<IRGraph> ret_graph = std::make_shared<IRGraph>(
       g->getName(), new_nodes, new_values, g->getInputNames(),
-      g->getOutputNames());
+      g->getOutputNames(), g->getBatchSize());
 
   auto part_info = TensorPartitioningGraphInfo{
       ret_graph, ranks, param_part, dist_ranks, {}, rank_value_names};

--- a/src/graph/ConvertGraph.h
+++ b/src/graph/ConvertGraph.h
@@ -41,7 +41,7 @@ class ConvertGraph {
 IRValue toIRValue(torch::jit::Value* value);
 std::shared_ptr<IRGraph> fromTorch(
     const std::string& name, const std::shared_ptr<torch::jit::Graph>& graph,
-    size_t real_input_num);
+    size_t real_input_num, int64_t batch_size);
 
 std::shared_ptr<IRGraph> guessBatchValuesByReachability(
     const std::shared_ptr<IRGraph>& g);

--- a/src/graph/Decomposition.h
+++ b/src/graph/Decomposition.h
@@ -51,6 +51,7 @@ struct EdgeInfo {};
 
 struct GraphInfo {
   std::string id;
+  int64_t batch_size;
 };
 
 typedef boost::adjacency_list<
@@ -455,8 +456,6 @@ std::unordered_map<std::string, GraphRoutes> getRoutesByGraph(
 
 template <typename Graph>
 std::shared_ptr<IRGraph> fromBGL(const Graph& b_graph) {
-  std::shared_ptr<IRGraph> irGraph = std::make_shared<IRGraph>();
-
   typename boost::graph_traits<Graph>::vertex_iterator i, end;
 
   std::vector<IRNode> nodes;
@@ -499,7 +498,7 @@ std::shared_ptr<IRGraph> fromBGL(const Graph& b_graph) {
 
   return std::make_shared<IRGraph>(
       b_graph[boost::graph_bundle].id, nodes, values, input_names,
-      output_names);
+      output_names, b_graph[boost::graph_bundle].batch_size);
 }
 
 BGraph toBGL(const std::shared_ptr<IRGraph>& ir_graph);
@@ -539,7 +538,6 @@ std::string toString(const GraphRoutes& routes);
 void fixNonBatchRanks(BGraph& g);
 std::vector<size_t> splitByValueSizes(const BGraph& g, int n_partition);
 void setRanksOnGraph(BGraph& g, const std::vector<size_t>& split);
-BGraph copyGraphWithBatch(const BGraph& g);
 
 typedef boost::adjacency_list<
     boost::vecS, boost::vecS, boost::bidirectionalS, std::shared_ptr<IRGraph>>

--- a/src/graph/GuessValueTypes.cpp
+++ b/src/graph/GuessValueTypes.cpp
@@ -150,8 +150,7 @@ std::shared_ptr<IRGraph> guessValueTypes(const std::shared_ptr<IRGraph>& g) {
     IRValue& in_val = values.at(bg[in].name);
     const IRType& type = in_val.getType();
     assert(type.getBaseType() == IRBaseType::TENSOR);
-    in_val.setBatch(true);
-
+    in_val.setBatch(true, g->getBatchSize());
     types[bg[in].id] = ValueType::BATCH;
   }
 
@@ -189,7 +188,7 @@ std::shared_ptr<IRGraph> guessValueTypes(const std::shared_ptr<IRGraph>& g) {
       switch (src_type) {
         case ValueType::BATCH: {
           IRValue& ir_val = values.at(bg[v].name);
-          ir_val.setBatch(true);
+          ir_val.setBatch(true, g->getBatchSize());
           break;
         }
         case ValueType::PARAM:
@@ -215,7 +214,7 @@ std::shared_ptr<IRGraph> guessValueTypes(const std::shared_ptr<IRGraph>& g) {
         types[bg[v].id] = ValueType::BATCH;
         assert(contains(node_map, bg[v].id));
         IRNode& ir_node = node_map.at(bg[v].id);
-        ir_node.setBatch(true);
+        ir_node.setBatch(true, g->getBatchSize());
       } else if (matchParamRule(src_types)) {
         //                    spdlog::info("match {} PARAM", bg[v].name);
         types[bg[v].id] = ValueType::PARAM;
@@ -248,8 +247,9 @@ std::shared_ptr<IRGraph> guessValueTypes(const std::shared_ptr<IRGraph>& g) {
     }
   }
 
-  const auto typed_graph = std::make_shared<IRGraph>(
-      g->getName(), nodes, values, g->getInputNames(), g->getOutputNames());
+  auto typed_graph = std::make_shared<IRGraph>(
+      g->getName(), nodes, values, g->getInputNames(), g->getOutputNames(), g->getBatchSize());
+
   //        std::stringstream ss;
   //        ss << "typed graph: " << *typed_graph;
   //        spdlog::info(ss.str());

--- a/src/graph/MLGraph.cpp
+++ b/src/graph/MLGraph.cpp
@@ -297,8 +297,12 @@ std::shared_ptr<IRGraph> merge(
       value_names.insert(v.first);
     }
   }
+
+  assert(g1->getBatchSize() == g2->getBatchSize());
+
   return std::make_shared<IRGraph>(
-      generateName("ML_"), nodes, merged_values, all_inputs, outputs);
+      generateName("ML_"), nodes, merged_values,
+      all_inputs, outputs, g1->getBatchSize());
 }
 
 bool ensureOutputsExist(const std::shared_ptr<IRGraph>& g) {

--- a/src/graph/Partitioner.h
+++ b/src/graph/Partitioner.h
@@ -83,7 +83,6 @@ class MLPartitioner {
 
   ProfilerUtil prof_util_;
   PartitioningConf conf_;
-  size_t batch_size_;
   bool coarsen_by_time_;
   int max_repl_num_;
 

--- a/src/graph/ProfilerUtil.cpp
+++ b/src/graph/ProfilerUtil.cpp
@@ -87,8 +87,8 @@ size_t getOptMemSize(
           // we have to keep memory for stashed gradients
           sum += val.getSizeInByte() * prof_in.opt_param_factor /
               zero_dist_num // optimizer state
-              / slice_num;
-          +val.getSizeInByte() / slice_num; // stashed gradients
+              / slice_num
+              + val.getSizeInByte() / slice_num; // stashed gradients
         } else {
           throw std::runtime_error(
               "Unexpected param type: " +

--- a/src/torch/TorchDriver.cpp
+++ b/src/torch/TorchDriver.cpp
@@ -205,7 +205,7 @@ std::shared_ptr<IRGraph> insertInValueHook(
 
           const std::string hook_out_name = in_name + "_hook_out";
           IRNode hook(op_name, {in_name, out_name_var}, {hook_out_name});
-          hook.setBatch(n.isBatch());
+          hook.setBatch(n.isBatch(), n.getBatchSize());
           hook.setCriterion(n.isCriterion());
           new_nodes.push_back(hook);
 
@@ -226,7 +226,7 @@ std::shared_ptr<IRGraph> insertInValueHook(
     }
 
     IRNode new_node(n.getName(), input_names, n.getOutputNames());
-    new_node.setBatch(n.isBatch());
+    new_node.setBatch(n.isBatch(), n.getBatchSize());
     new_node.setCriterion(n.isCriterion());
     new_nodes.push_back(new_node);
 
@@ -238,7 +238,7 @@ std::shared_ptr<IRGraph> insertInValueHook(
 
   return std::make_shared<IRGraph>(
       g->getName(), new_nodes, new_values, g->getInputNames(),
-      g->getOutputNames());
+      g->getOutputNames(), g->getBatchSize());
 }
 
 std::shared_ptr<IRGraph> insertOutValueHook(
@@ -268,7 +268,7 @@ std::shared_ptr<IRGraph> insertOutValueHook(
     }
 
     IRNode new_node(n.getName(), input_names, n.getOutputNames());
-    new_node.setBatch(n.isBatch());
+    new_node.setBatch(n.isBatch(), n.getBatchSize());
     new_node.setCriterion(n.isCriterion());
     new_nodes.push_back(new_node);
 
@@ -288,7 +288,7 @@ std::shared_ptr<IRGraph> insertOutValueHook(
 
         const std::string hook_out_name = out_name + "_hook_out";
         IRNode hook(op_name, {out_name, out_name_var}, {hook_out_name});
-        hook.setBatch(n.isBatch());
+        hook.setBatch(n.isBatch(), n.getBatchSize());
         hook.setCriterion(n.isCriterion());
         new_nodes.push_back(hook);
 
@@ -311,7 +311,8 @@ std::shared_ptr<IRGraph> insertOutValueHook(
   }
 
   return std::make_shared<IRGraph>(
-      g->getName(), new_nodes, new_values, g->getInputNames(), output_names);
+      g->getName(), new_nodes, new_values, g->getInputNames(),
+      output_names, g->getBatchSize());
 }
 
 std::shared_ptr<IRGraph> insertOffloadingPreHooks(


### PR DESCRIPTION
A shape mismatch error happened while training.
The reason of this error seems to be that the first dimension size of (batch) tensors was assigned the batch size, but it is not always equal to the batch size (e.g., it can be multiples of the batch size).

This PR tries to fix this issue by assigning a batch size to each IR graph and value, which will make the batch size property clearer.
By doing so, we can know the batch size of a tensor, even if the first dimension size of the tensor is not equal to its batch size.

This PR also includes some minor fixes and refactoring (e.g., removing dead code).

NOTE: this PR is not seriously tested.